### PR TITLE
Add support for starting/stopping daemons in .lunchy profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ lunchy
 lunchy-go
 .DS_Store
 
+.lunchy

--- a/lunchy.go
+++ b/lunchy.go
@@ -364,7 +364,14 @@ func readProfile() []string {
 	lines := strings.Split(strings.TrimSpace(string(buff)), "\n")
 
 	for _, l := range lines {
-		result = append(result, strings.TrimSpace(l))
+		line := strings.TrimSpace(l)
+
+		// Skip comments (starts with #)
+		if line[0] == 35 {
+			continue
+		}
+
+		result = append(result, line)
 	}
 
 	return result

--- a/lunchy.go
+++ b/lunchy.go
@@ -309,6 +309,57 @@ func scanPath(args []string) {
 	}
 }
 
+// Get full path to lunchy profile file
+func profilePath() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return dir + "/.lunchy"
+}
+
+// Get daemon names specified in lunchy profile
+func readProfile() []string {
+	path := profilePath()
+	if path == "" {
+		return []string{}
+	}
+
+	buff, err := ioutil.ReadFile(path)
+	if err != nil {
+		return []string{}
+	}
+
+	result := []string{}
+	lines := strings.Split(strings.TrimSpace(string(buff)), "\n")
+
+	for _, l := range lines {
+		result = append(result, strings.TrimSpace(l))
+	}
+
+	return result
+}
+
+func startProfile() {
+	for _, name := range readProfile() {
+		for _, plist := range getPlists() {
+			if strings.Index(plist, name) != -1 {
+				startDaemon(plist)
+			}
+		}
+	}
+}
+
+func stopProfile() {
+	for _, name := range readProfile() {
+		for _, plist := range getPlists() {
+			if strings.Index(plist, name) != -1 {
+				stopDaemon(plist)
+			}
+		}
+	}
+}
+
 func fatal(message string) {
 	fmt.Println(message)
 	os.Exit(1)

--- a/lunchy.go
+++ b/lunchy.go
@@ -370,41 +370,39 @@ func readProfile() []string {
 	return result
 }
 
-func startProfile() {
-	fmt.Println("Starting daemons in profile:", profilePath())
+func plistsAction(names []string, action string) {
+	plists := getPlists()
 
-	for _, name := range readProfile() {
-		for _, plist := range getPlists() {
+	for _, name := range names {
+		for _, plist := range plists {
 			if strings.Index(plist, name) != -1 {
-				startDaemon(plist)
+				switch action {
+				case "start":
+					startDaemon(plist)
+				case "stop":
+					stopDaemon(plist)
+				case "restart":
+					stopDaemon(plist)
+					startDaemon(plist)
+				}
 			}
 		}
 	}
+}
+
+func startProfile() {
+	fmt.Println("Starting daemons in profile:", profilePath())
+	plistsAction(readProfile(), "start")
 }
 
 func stopProfile() {
 	fmt.Println("Stopping daemons in profile:", profilePath())
-
-	for _, name := range readProfile() {
-		for _, plist := range getPlists() {
-			if strings.Index(plist, name) != -1 {
-				stopDaemon(plist)
-			}
-		}
-	}
+	plistsAction(readProfile(), "stop")
 }
 
 func restartProfile() {
 	fmt.Println("Restarting daemons in profile:", profilePath())
-
-	for _, name := range readProfile() {
-		for _, plist := range getPlists() {
-			if strings.Index(plist, name) != -1 {
-				stopDaemon(plist)
-				startDaemon(plist)
-			}
-		}
-	}
+	plistsAction(readProfile(), "restart")
 }
 
 func fatal(message string) {

--- a/lunchy.go
+++ b/lunchy.go
@@ -136,7 +136,15 @@ func exitWithInvalidArgs(args []string, msg string) {
 }
 
 func startDaemons(args []string) {
-	exitWithInvalidArgs(args, "name required")
+	// Check if name pattern is not given and try profiles
+	if len(args) == 2 {
+		if profileExists() {
+			startProfile()
+			return
+		} else {
+			exitWithInvalidArgs(args, "name required")
+		}
+	}
 
 	name := args[2]
 
@@ -160,7 +168,15 @@ func startDaemon(name string) {
 }
 
 func stopDaemons(args []string) {
-	exitWithInvalidArgs(args, "name required")
+	// Check if name pattern is not given and try profiles
+	if len(args) == 2 {
+		if profileExists() {
+			stopProfile()
+			return
+		} else {
+			exitWithInvalidArgs(args, "name required")
+		}
+	}
 
 	name := args[2]
 
@@ -319,6 +335,11 @@ func profilePath() string {
 	return dir + "/.lunchy"
 }
 
+// Check if profile file exists
+func profileExists() bool {
+	return fileExists(profilePath())
+}
+
 // Get daemon names specified in lunchy profile
 func readProfile() []string {
 	path := profilePath()
@@ -342,6 +363,8 @@ func readProfile() []string {
 }
 
 func startProfile() {
+	fmt.Println("Starting daemons in profile:", profilePath())
+
 	for _, name := range readProfile() {
 		for _, plist := range getPlists() {
 			if strings.Index(plist, name) != -1 {
@@ -352,6 +375,8 @@ func startProfile() {
 }
 
 func stopProfile() {
+	fmt.Println("Stopping daemons in profile:", profilePath())
+
 	for _, name := range readProfile() {
 		for _, plist := range getPlists() {
 			if strings.Index(plist, name) != -1 {

--- a/lunchy.go
+++ b/lunchy.go
@@ -200,7 +200,15 @@ func stopDaemon(name string) {
 }
 
 func restartDaemons(args []string) {
-	exitWithInvalidArgs(args, "name required")
+	// Check if name pattern is not given and try profiles
+	if len(args) == 2 {
+		if profileExists() {
+			restartProfile()
+			return
+		} else {
+			exitWithInvalidArgs(args, "name required")
+		}
+	}
 
 	name := args[2]
 
@@ -381,6 +389,19 @@ func stopProfile() {
 		for _, plist := range getPlists() {
 			if strings.Index(plist, name) != -1 {
 				stopDaemon(plist)
+			}
+		}
+	}
+}
+
+func restartProfile() {
+	fmt.Println("Restarting daemons in profile:", profilePath())
+
+	for _, name := range readProfile() {
+		for _, plist := range getPlists() {
+			if strings.Index(plist, name) != -1 {
+				stopDaemon(plist)
+				startDaemon(plist)
 			}
 		}
 	}


### PR DESCRIPTION
This is ongoing work to support lunchy profiles. Profile is a single file `.lunchy` in a project
directory that contains names of services/daemons to be started/stopped with a single command.
This is very helpful when switching between projects that use different stacks.

Examples `.lunchy` profile:

```
postgres
redis
elasticsearch
```

Usage:

```
lunchy start
lunchy stop
```

Start/stop command without an argument will indicate an intention to start/stop programs from
the profile file. 